### PR TITLE
BUG: All intermediate files need deleting

### DIFF
--- a/nifti2/nifti_regress_test/cmake_testscripts/comment_test.sh
+++ b/nifti2/nifti_regress_test/cmake_testscripts/comment_test.sh
@@ -12,6 +12,7 @@ OUT_DATA=$(dirname ${DATA}) #Need to write to separate directory
 cd ${OUT_DATA}
 
 rm -f ${OUT_DATA}/f4.comment.nii
+rm -f ${OUT_DATA}/f4.to.clear.nii
 
 # add some comment and afni extensions, then display them
 if \


### PR DESCRIPTION
Test failed on second run due to existence of temporary output files existing during the second run.

335: ** failure: NIFTI header file    'nifti_clib/cmake-build-debug/_deps/fetch_testing_data-src/f4.to.clear.nii' already exists
335: ** failed to set names, prefix = 'nifti_clib/cmake-build-debug/_deps/fetch_testing_data-src/f4.to.clear.nii'

Fix script to remove temporary files at begining of running the tests.