### PR TITLE
Removed unneeded check for NULL before free()ing

### DIFF
--- a/cifti/afni_xml.c
+++ b/cifti/afni_xml.c
@@ -220,7 +220,7 @@ afni_xml_list axml_read_file(const char * fname, int read_data)
    }
 
    fclose(fp);
-   if( buf ) free(buf);        /* parser buffer */
+   free(buf);        /* parser buffer */
    XML_ParserFree(parser);
 
    if(xd->verb > 1) fprintf(stderr,"++ done parsing XML file %s\n", fname);
@@ -307,7 +307,7 @@ afni_xml_list axml_read_buf(const char * buf_in, int64_t bin_len)
         }
     }
 
-    if( buf ) free(buf);        /* parser buffer */
+    free(buf);        /* parser buffer */
     XML_ParserFree(parser);
 
     if(xd->verb > 1) fprintf(stderr,"++ done parsing XML buffer\n");
@@ -447,8 +447,8 @@ int axml_add_attrs(afni_xml_t * ax, const char ** attr)
    if( ! ax->attrs.name || ! ax->attrs.value ) {
       fprintf(stderr,"** NAX: failed to alloc 2 sets of %d char*\n", natr);
       ax->attrs.length = 0;
-      if( ax->attrs.name )  free(ax->attrs.name);
-      if( ax->attrs.value ) free(ax->attrs.value);
+      free(ax->attrs.name);
+      free(ax->attrs.value);
       ax->attrs.name = ax->attrs.value = NULL;
       return 1;
    }
@@ -492,25 +492,25 @@ int axml_free_xml_t(afni_xml_t * ax)
 
    if( !ax ) return 0;
 
-   if( ax->name )  { free(ax->name);  ax->name  = NULL; }
-   if( ax->xtext ) { free(ax->xtext); ax->xtext = NULL; }
-   if( ax->bdata ) { free(ax->bdata); ax->bdata = NULL; }
+   free(ax->name);  ax->name  = NULL;
+   free(ax->xtext); ax->xtext = NULL;
+   free(ax->bdata); ax->bdata = NULL;
    ax->xlen = 0;
 
    /* free all attributes */
    for(ind = 0; ind < ax->attrs.length; ind++ ) {
-      if( ax->attrs.name  && ax->attrs.name[ind] )  free(ax->attrs.name[ind]);
-      if( ax->attrs.value && ax->attrs.value[ind] ) free(ax->attrs.value[ind]);
+      if( ax->attrs.name )  free(ax->attrs.name[ind]);
+      if( ax->attrs.value ) free(ax->attrs.value[ind]);
    }
-   if( ax->attrs.name )  { free(ax->attrs.name);  ax->attrs.name = NULL; }
-   if( ax->attrs.value ) { free(ax->attrs.value); ax->attrs.value = NULL; }
+   free(ax->attrs.name);  ax->attrs.name = NULL;
+   free(ax->attrs.value); ax->attrs.value = NULL;
    ax->attrs.length = 0;
 
    /* and free children */
    if( ax->nchild > 0 && ax->xchild )
       for( ind=0; ind < ax->nchild; ind++ ) axml_free_xml_t(ax->xchild[ind]);
    ax->nchild = 0;
-   if( ax->xchild ) { free(ax->xchild); ax->xchild = NULL; }
+   free(ax->xchild); ax->xchild = NULL;
    ax->xparent = NULL;
 
    free(ax);
@@ -864,7 +864,7 @@ static char * strip_whitespace(const char * str, int slen)
    int           len, ifirst, ilast;  /* first non-white char and AFTER last */
 
    /* backdoor to free this memory, e.g. on call to free list */
-   if(!str && slen == -2){if(buf) { free(buf); buf=NULL; } blen=0; return 0; }
+   if(!str && slen == -2){ free(buf); buf=NULL; blen=0; return 0; }
 
    /* if string is long, forget it */
    if( !str || slen > 1024 ) return (char *)str;

--- a/fsliolib/fslio.c
+++ b/fsliolib/fslio.c
@@ -2087,8 +2087,8 @@ FSLIO * FslReadHeader(char *fname)
   /** read header information */
   fslio->niftiptr = nifti_image_read(hdrname, 0);
 
-  if( imgname ) free(imgname);
-  if( hdrname ) free(hdrname);
+  free(imgname);
+  free(hdrname);
 
   if (fslio->niftiptr == NULL) {
         FSLIOERR("FslReadHeader: error reading header information");

--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -802,7 +802,7 @@ void nifti_free_NBL( nifti_brick_list * NBL )
 
    if( NBL->bricks ){
       for( c = 0; c < NBL->nbricks; c++ )
-         if( NBL->bricks[c] ) free(NBL->bricks[c]);
+         free(NBL->bricks[c]);
       free(NBL->bricks);
       NBL->bricks = NULL;
    }
@@ -970,8 +970,8 @@ static int nifti_copynsort(int nbricks, const int * blist, int ** slist,
 
    if( !*slist || !*sindex ){
       fprintf(stderr,"** NCS: failed to alloc %d ints for sorting\n",nbricks);
-      if(*slist)  free(*slist);   /* maybe one succeeded */
-      if(*sindex) free(*sindex);
+      free(*slist);   /* maybe one succeeded */
+      free(*sindex);
       return -1;
    }
 
@@ -3100,8 +3100,8 @@ int nifti_set_filenames( nifti_image * nim, const char * prefix, int check,
    if( g_opts.debug > 1 )
       fprintf(stderr,"+d modifying output filenames using prefix %s\n", prefix);
 
-   if( nim->fname ) free(nim->fname);
-   if( nim->iname ) free(nim->iname);
+   free(nim->fname);
+   free(nim->iname);
    nim->fname = nifti_makehdrname(prefix, nim->nifti_type, check, comp);
    nim->iname = nifti_makeimgname(prefix, nim->nifti_type, check, comp);
    if( !nim->fname || !nim->iname ){
@@ -5098,9 +5098,9 @@ void nifti_image_unload( nifti_image *nim )
 void nifti_image_free( nifti_image *nim )
 {
    if( nim == NULL ) return ;
-   if( nim->fname != NULL ) free(nim->fname) ;
-   if( nim->iname != NULL ) free(nim->iname) ;
-   if( nim->data  != NULL ) free(nim->data ) ;
+   free(nim->fname) ;
+   free(nim->iname) ;
+   free(nim->data ) ;
    (void)nifti_free_extensions( nim ) ;
    free(nim) ; }
 
@@ -5122,7 +5122,7 @@ int nifti_free_extensions( nifti_image *nim )
    if( nim == NULL ) return -1;
    if( nim->num_ext > 0 && nim->ext_list ){
       for( c = 0; c < nim->num_ext; c++ )
-         if ( nim->ext_list[c].edata ) free(nim->ext_list[c].edata);
+         free(nim->ext_list[c].edata);
       free(nim->ext_list);
    }
    /* or if it is inconsistent, warn the user (if we are not in quiet mode) */


### PR DESCRIPTION
free(NULL) is a well-defined nop.

Removing this makes the code easier to read.

Only did this in trivial cases.