### PR TITLE
ENH: initial -fbounds-safety work

### DIFF
--- a/cifti/afni_xml_tool.c
+++ b/cifti/afni_xml_tool.c
@@ -12,8 +12,8 @@
 /* ----------------------------------------------------------------- */
 /* define and declare main option struct */
 typedef struct {
-   char * fin;
-   char * fout;
+   const char * fin;
+   const char * fout;
    int    disp_xlist;
    int    verb;
    int    xverb;
@@ -24,12 +24,12 @@ opts_t gopt;
 
 /* ----------------------------------------------------------------- */
 /* protos */
-int process_args         (int argc, char * argv[], opts_t * opts);
+int process_args         (int argc, const char * argv[], opts_t * opts);
 int process              (opts_t * opts);
 int show_help            (void);
 
 /* ----------------------------------------------------------------- */
-int main(int argc, char * argv[])
+int main(int argc, const char * argv[])
 {
    int rv;
 
@@ -45,7 +45,7 @@ int main(int argc, char * argv[])
 }
 
 /* ----------------------------------------------------------------- */
-int process_args(int argc, char * argv[], opts_t * opts)
+int process_args(int argc, const char * argv[], opts_t * opts)
 {
    int ac;
 

--- a/cifti/cifti_tool.c
+++ b/cifti/cifti_tool.c
@@ -37,14 +37,14 @@ static const char * g_history[] =
   "----------------------------------------------------------------------\n"
 };
 
-static char g_version[] = "cifti_tool version 0.3, 21 August, 2015";
+static const char g_version[] = "cifti_tool version 0.3, 21 August, 2015";
 
 /* ----------------------------------------------------------------- */
 /* define and declare main option struct */
 typedef struct {
-   char * fin;
-   char * fout;
-   char * eval_type;
+   const char * fin;
+   const char * fout;
+   const char * eval_type;
    int    verb;
    int    vread;
    int    as_cext;
@@ -66,7 +66,7 @@ int eval_cifti_extension(afni_xml_t * ax, opts_t * opts);
 int show_cifti_summary  (FILE * fp, afni_xml_t * ax, int verb);
 
 /* main */
-int process_args        (int argc, char * argv[], opts_t * opts);
+int process_args        (int argc, const char * argv[], opts_t * opts);
 int process             (opts_t * opts);
 int show_help           (void);
 int show_hist           (void);
@@ -81,10 +81,10 @@ int ax_show_names       (FILE * fp, afni_xml_t * ax, int depth);
 
 /* stream */
 int          close_stream        (FILE * fp);
-FILE       * open_write_stream   (char * fname);
+FILE       * open_write_stream   (const char * fname);
 
 /* ----------------------------------------------------------------- */
-int main(int argc, char * argv[])
+int main(int argc, const char * argv[])
 {
    int rv;
 
@@ -101,7 +101,7 @@ int main(int argc, char * argv[])
 }
 
 /* ----------------------------------------------------------------- */
-int process_args(int argc, char * argv[], opts_t * opts)
+int process_args(int argc, const char * argv[], opts_t * opts)
 {
    int ac;
 
@@ -269,7 +269,7 @@ int eval_cifti_extension(afni_xml_t * ax, opts_t * opts)
 }
 
 /* look for stdin/stdout */
-FILE * open_write_stream(char * fname)
+FILE * open_write_stream(const char * fname)
 {
    FILE * fp = NULL;
 

--- a/nifti2/clib_02_nifti2.c
+++ b/nifti2/clib_02_nifti2.c
@@ -42,10 +42,11 @@ static int show_help( void )
    return 0;
 }
 
-int main(int argc, char * argv[])
+int main(int argc, const char * argv[])
 {
    nifti_image * nim=NULL;
-   char        * fin=NULL, * fout=NULL;
+   const char  * fin=NULL;
+   const char  * fout=NULL;
    int           ac, disp_float_eg=0;
 
    if( argc < 2 ) return show_help();   /* typing '-help' is sooo much work */

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -488,7 +488,7 @@ static void compute_strides(int64_t *strides,const int64_t *size,int nbyper);
 /* NBL routines */
 static int  nifti_load_NBL_bricks(nifti_image * nim , const int64_t * slist,
                        const int64_t * sindex, nifti_brick_list * NBL, znzFile fp );
-static int  nifti_alloc_NBL_mem(  nifti_image * nim, int64_t nbricks,
+static int  nifti_alloc_NBL_mem(  const nifti_image * nim, int64_t nbricks,
                                   nifti_brick_list * nbl);
 static int  nifti_copynsort(int64_t nbricks, const int64_t *blist,
                             int64_t **slist, int64_t **sindex);
@@ -1001,7 +1001,7 @@ static int nifti_load_NBL_bricks( nifti_image * nim , const int64_t * slist,
  *
  * return 0 on success, -1 on failure
  *----------------------------------------------------------------------*/
-static int nifti_alloc_NBL_mem(nifti_image * nim, int64_t nbricks,
+static int nifti_alloc_NBL_mem(const nifti_image * nim, int64_t nbricks,
                                nifti_brick_list * nbl)
 {
    int64_t c;

--- a/nifti2/nifti2_io.c
+++ b/nifti2/nifti2_io.c
@@ -500,8 +500,8 @@ static int  rci_read_data(nifti_image *nim, int64_t *pivots, int64_t *prods,
                           int nprods, const int64_t dims[], char *data,
                           znzFile fp, int64_t base_offset);
 static int rci_alloc_mem(void **data, const int64_t prods[8], int nprods, int nbyper);
-static int  make_pivot_list(nifti_image * nim, const int64_t dims[],
-                            int64_t pivots[], int64_t prods[], int * nprods );
+static int  make_pivot_list(nifti_image * nim, const int64_t dims[8],
+                            int64_t pivots[8], int64_t prods[8], int * nprods );
 
 /* misc */
 static int   compare_strlist   (const char * str, char ** strlist, int len);
@@ -7179,7 +7179,7 @@ nifti_image* nifti_simple_init_nim(void)
 
    \return pointer to allocated nifti_2_header struct
 *//*--------------------------------------------------------------------*/
-nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[],
+nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[8],
                                           int arg_dtype)
 {
    nifti_2_header * nhdr;
@@ -7260,7 +7260,7 @@ nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[],
 
    \return pointer to allocated nifti_1_header struct
 *//*--------------------------------------------------------------------*/
-nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[],
+nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[8],
                                           int arg_dtype)
 {
    nifti_1_header * nhdr;
@@ -7343,7 +7343,7 @@ nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[],
 
    \return pointer to allocated nifti_image struct
 *//*--------------------------------------------------------------------*/
-nifti_image * nifti_make_new_nim(const int64_t dims[], int datatype,
+nifti_image * nifti_make_new_nim(const int64_t dims[8], int datatype,
                                  int data_fill)
 {
    nifti_image    * nim;
@@ -9495,8 +9495,8 @@ static int rci_alloc_mem(void **data, const int64_t prods[8], int nprods, int nb
    wants to collapse a dimension.  The last pivot should always be zero
    (note that we have space for that in the lists).
 */
-static int make_pivot_list(nifti_image *nim, const int64_t dims[],
-                           int64_t pivots[], int64_t prods[], int * nprods )
+static int make_pivot_list(nifti_image *nim, const int64_t dims[8],
+                           int64_t pivots[8], int64_t prods[8], int * nprods )
 {
    int len = 0;
    int64_t dind = nim->dim[0];

--- a/nifti2/nifti2_io.h
+++ b/nifti2/nifti2_io.h
@@ -592,13 +592,13 @@ NI2_API char * nifti_makebasename(const char* fname);
 /* other routines */
 NI2_API int   nifti_convert_nim2n1hdr(const nifti_image* nim, nifti_1_header * hdr);
 NI2_API int   nifti_convert_nim2n2hdr(const nifti_image* nim, nifti_2_header * hdr);
-NI2_API nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[], int arg_dtype);
-NI2_API nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[], int arg_dtype);
+NI2_API nifti_1_header * nifti_make_new_n1_header(const int64_t arg_dims[8], int arg_dtype);
+NI2_API nifti_2_header * nifti_make_new_n2_header(const int64_t arg_dims[8], int arg_dtype);
 NI2_API void           * nifti_read_header(const char *hname, int *nver,    int check);
 NI2_API nifti_1_header * nifti_read_n1_hdr(const char *hname, int *swapped, int check);
 NI2_API nifti_2_header * nifti_read_n2_hdr(const char *hname, int *swapped, int check);
 NI2_API nifti_image    * nifti_copy_nim_info(const nifti_image * src);
-NI2_API nifti_image    * nifti_make_new_nim(const int64_t dims[], int datatype,
+NI2_API nifti_image    * nifti_make_new_nim(const int64_t dims[8], int datatype,
                                     int data_fill);
 
 

--- a/nifti2/nifti_tool.c
+++ b/nifti2/nifti_tool.c
@@ -204,8 +204,8 @@ static const char * g_history[] =
   "   - add -convert2dtype, -convert_verify, -convert_fail_choice\n",
   "----------------------------------------------------------------------\n"
 };
-static char g_version[] = "2.13";
-static char g_version_date[] = "February 27, 2022";
+static const char g_version[] = "2.13";
+static const char g_version_date[] = "February 27, 2022";
 static int  g_debug = 1;
 
 #include <limits.h>
@@ -246,7 +246,7 @@ static const char * g_nim_timing_fnames[NT_NIM_TIME_NFIELDS] = {
      "dim", "pixdim", "xyz_units", "time_units" };
 
 
-int main( int argc, char * argv[] )
+int main( int argc, const char * argv[] )
 {
    nt_opts opts;
    int     rv;
@@ -325,7 +325,7 @@ int main( int argc, char * argv[] )
 /*----------------------------------------------------------------------
  * process user options, return 0 on success
  *----------------------------------------------------------------------*/
-int process_opts( int argc, char * argv[], nt_opts * opts )
+int process_opts( int argc, const char * argv[], nt_opts * opts )
 {
    int ac, count;
 
@@ -724,7 +724,7 @@ int process_opts( int argc, char * argv[], nt_opts * opts )
 /*----------------------------------------------------------------------
  * verify that the options make sense
  *----------------------------------------------------------------------*/
-int verify_opts( nt_opts * opts, char * prog )
+int verify_opts( nt_opts * opts, const char * prog )
 {
    int ac, errs = 0;   /* number of requested action types */
 
@@ -849,7 +849,7 @@ int verify_opts( nt_opts * opts, char * prog )
  * re-assemble the command string into opts->command
  * (commands are currently limited to 2048 bytes)
  *----------------------------------------------------------------------*/
-int fill_cmd_string( nt_opts * opts, int argc, char * argv[])
+int fill_cmd_string( nt_opts * opts, int argc, const char * argv[])
 {
    char * cp;
    size_t len, c, remain = sizeof(opts->command);  /* max command len */
@@ -955,7 +955,7 @@ int add_string(str_list * slist, const char * str)
 /*----------------------------------------------------------------------
  * display information on using the program
  *----------------------------------------------------------------------*/
-int usage(char * prog, int level)
+int usage(const char * prog, int level)
 {
    int c, len;
    if( level == USE_SHORT )

--- a/nifti2/nifti_tool.h
+++ b/nifti2/nifti_tool.h
@@ -60,7 +60,7 @@ typedef struct{
    int      cnvt_fail_choice;    /* what if conversion fails      */
    int      debug, keep_hist;    /* debug level and history flag  */
    int      overwrite;           /* overwrite flag                */
-   char *   prefix;              /* for output file               */
+   const char *   prefix;              /* for output file               */
    str_list elist;               /* extension strings             */
    int_list etypes;              /* extension type list           */
    str_list flist;               /* fields (to display or modify) */
@@ -299,7 +299,7 @@ NI2_API int disp_field       (const char *mesg,field_s *fieldp,void *str,int nfi
 NI2_API int disp_field_s_list(const char * mesg, field_s *, int nfields);
 NI2_API int disp_nt_opts     ( const char *mesg, nt_opts * opts);
 NI2_API int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
-NI2_API int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
+NI2_API int fill_cmd_string  (nt_opts * opts, int argc, const char * argv[]);
 NI2_API int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
 NI2_API int fill_hdr1_field_array(field_s * nh_fields);
 NI2_API int fill_hdr2_field_array(field_s * nh_fields);
@@ -308,11 +308,11 @@ NI2_API int fill_nim2_field_array(field_s * nim_fields);
 NI2_API int fill_ana_field_array(field_s * ah_fields);
 NI2_API int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
 NI2_API int modify_field     (void * basep, field_s * field, const char * data);
-NI2_API int process_opts     (int argc, char * argv[], nt_opts * opts);
+NI2_API int process_opts     (int argc, const char * argv[], nt_opts * opts);
 NI2_API int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
-NI2_API int usage            (char * prog, int level);
+NI2_API int usage            (const char * prog, int level);
 NI2_API int use_full         (void);
-NI2_API int verify_opts      (nt_opts * opts, char * prog);
+NI2_API int verify_opts      (nt_opts * opts, const char * prog);
 NI2_API int write_hdr_to_file (nifti_1_header * nhdr, const char * fname);
 NI2_API int write_hdr2_to_file(nifti_2_header * nhdr, const char * fname);
 

--- a/nifticdf/nifti_stats.c
+++ b/nifticdf/nifti_stats.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int main( int argc , char *argv[] )
+int main( int argc , const char *argv[] )
 {
    double val , p , p1=0.0,p2=0.0,p3=0.0 ;
    double vbot,vtop,vdel ;

--- a/nifticdf/nifticdf.c
+++ b/nifticdf/nifticdf.c
@@ -11042,7 +11042,7 @@ char const * const inam[]={ NULL , NULL ,
     - Returns -1 if name isn't found in the table.
 ----------------------------------------------------------------------------*/
 
-int nifti_intent_code( char *name )
+int nifti_intent_code( const char *name )
 {
    char *unam , *upt ;
    int ii ;

--- a/nifticdf/nifticdf.h
+++ b/nifticdf/nifticdf.h
@@ -82,7 +82,7 @@
 
 NCDF_API extern char const * const inam[];
 
-NCDF_API int nifti_intent_code( char *name );
+NCDF_API int nifti_intent_code( const char *name );
 NCDF_API double nifti_stat2cdf( double val, int code, double p1,double p2,double p3 );
 NCDF_API double nifti_stat2rcdf( double val, int code, double p1,double p2,double p3 );
 NCDF_API double nifti_cdf2stat( double p , int code, double p1,double p2,double p3 );

--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -433,10 +433,10 @@ static int  nifti_NBL_matches_nim(const nifti_image *nim,
 
 /* for nifti_read_collapsed_image: */
 static int  rci_read_data(nifti_image *nim, int *pivots, int *prods, int nprods,
-                  const int dims[], char *data, znzFile fp, size_t base_offset);
+                  const int dims[8], char *data, znzFile fp, size_t base_offset);
 static int  rci_alloc_mem(void ** data, const int prods[8], int nprods, int nbyper );
-static int  make_pivot_list(nifti_image * nim, const int dims[], int pivots[],
-                            int prods[], int * nprods );
+static int  make_pivot_list(nifti_image * nim, const int dims[8], int pivots[8],
+                            int prods[8], int * nprods );
 
 /* misc */
 static int   compare_strlist   (const char * str, char ** strlist, int len);
@@ -5348,7 +5348,7 @@ nifti_image* nifti_simple_init_nim(void)
 
    \return pointer to allocated nifti_1_header struct
 *//*--------------------------------------------------------------------*/
-nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype)
+nifti_1_header * nifti_make_new_header(const int arg_dims[8], int arg_dtype)
 {
    nifti_1_header * nhdr;
    const int        default_dims[8] = { 3, 1, 1, 1, 0, 0, 0, 0 };
@@ -5427,7 +5427,7 @@ nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype)
 
    \return pointer to allocated nifti_image struct
 *//*--------------------------------------------------------------------*/
-nifti_image * nifti_make_new_nim(const int dims[], int datatype, int data_fill)
+nifti_image * nifti_make_new_nim(const int dims[8], int datatype, int data_fill)
 {
    nifti_image    * nim;
    nifti_1_header * nhdr;
@@ -7282,7 +7282,7 @@ int nifti_read_subregion_image( nifti_image * nim,
    return 0 on success, < 0 on failure
 */
 static int rci_read_data(nifti_image * nim, int * pivots, int * prods,
-      int nprods, const int dims[], char * data, znzFile fp, size_t base_offset)
+      int nprods, const int dims[8], char * data, znzFile fp, size_t base_offset)
 {
    size_t sublen, offset, read_size;
    int    c;
@@ -7396,8 +7396,8 @@ static int rci_alloc_mem(void ** data, const int prods[8], int nprods, int nbype
    wants to collapse a dimension.  The last pivot should always be zero
    (note that we have space for that in the lists).
 */
-static int make_pivot_list(nifti_image * nim, const int dims[], int pivots[],
-                                              int prods[], int * nprods )
+static int make_pivot_list(nifti_image * nim, const int dims[8], int pivots[8],
+                                              int prods[8], int * nprods )
 {
    int len, dim_index;
 

--- a/niftilib/nifti1_io.c
+++ b/niftilib/nifti1_io.c
@@ -424,7 +424,7 @@ static int  nifti_fill_extension(nifti1_extension * ext, const char * data,
 
 /* NBL routines */
 static int  nifti_load_NBL_bricks(nifti_image * nim , const int * slist, const int * sindex,                                  nifti_brick_list * NBL, znzFile fp );
-static int  nifti_alloc_NBL_mem(  nifti_image * nim, int nbricks,
+static int  nifti_alloc_NBL_mem(  const nifti_image * nim, int nbricks,
                                   nifti_brick_list * nbl);
 static int  nifti_copynsort(int nbricks, const int *blist, int **slist,
                             int **sindex);
@@ -901,7 +901,7 @@ static int nifti_load_NBL_bricks( nifti_image * nim , const int * slist, const i
  *
  * return 0 on success, -1 on failure
  *----------------------------------------------------------------------*/
-static int nifti_alloc_NBL_mem(nifti_image * nim, int nbricks,
+static int nifti_alloc_NBL_mem(const nifti_image * nim, int nbricks,
                                nifti_brick_list * nbl)
 {
    int c;

--- a/niftilib/nifti1_io.h
+++ b/niftilib/nifti1_io.h
@@ -421,10 +421,10 @@ NIO_API char * nifti_makebasename(const char* fname);
 
 /* other routines */
 NIO_API struct nifti_1_header   nifti_convert_nim2nhdr(const nifti_image* nim);
-NIO_API nifti_1_header * nifti_make_new_header(const int arg_dims[], int arg_dtype);
+NIO_API nifti_1_header * nifti_make_new_header(const int arg_dims[8], int arg_dtype);
 NIO_API nifti_1_header * nifti_read_header(const char *hname, int *swapped, int check);
 NIO_API nifti_image    * nifti_copy_nim_info(const nifti_image * src);
-NIO_API nifti_image    * nifti_make_new_nim(const int dims[], int datatype,
+NIO_API nifti_image    * nifti_make_new_nim(const int dims[8], int datatype,
                                                       int data_fill);
 NIO_API nifti_image    * nifti_simple_init_nim(void);
 NIO_API nifti_image    * nifti_convert_nhdr2nim(struct nifti_1_header nhdr,

--- a/niftilib/nifti1_test.c
+++ b/niftilib/nifti1_test.c
@@ -14,7 +14,7 @@ static int local_fileexists(const char* fname)
 
 /****************************************************************************/
 
-int main( int argc , char *argv[] )
+int main( int argc , const char *argv[] )
 {
    nifti_image *nim ;
    int          iarg=1 , outmode=1 , argn, usegzip=0;

--- a/niftilib/nifti1_tool.c
+++ b/niftilib/nifti1_tool.c
@@ -159,7 +159,7 @@ static const char * g_history[] =
   "   - changed ana originator from char to short\n"
   "----------------------------------------------------------------------\n"
 };
-static char g_version[] = "version 1.24 (September 26, 2012)";
+static const char g_version[] = "version 1.24 (September 26, 2012)";
 static int  g_debug = 1;
 
 #include <limits.h>
@@ -187,7 +187,7 @@ static field_s g_hdr_fields[NT_HDR_NUM_FIELDS];    /* nifti_1_header fields */
 static field_s g_ana_fields[NT_ANA_NUM_FIELDS];    /* nifti_analyze75       */
 static field_s g_nim_fields[NT_NIM_NUM_FIELDS];    /* nifti_image fields    */
 
-int main( int argc, char * argv[] )
+int main( int argc, const char * argv[] )
 {
    nt_opts opts;
    int     rv;
@@ -249,7 +249,7 @@ int main( int argc, char * argv[] )
 /*----------------------------------------------------------------------
  * process user options, return 0 on success
  *----------------------------------------------------------------------*/
-int process_opts( int argc, char * argv[], nt_opts * opts )
+int process_opts( int argc, const char * argv[], nt_opts * opts )
 {
    int ac;
 
@@ -559,7 +559,7 @@ int process_opts( int argc, char * argv[], nt_opts * opts )
 /*----------------------------------------------------------------------
  * verify that the options make sense
  *----------------------------------------------------------------------*/
-int verify_opts( nt_opts * opts, char * prog )
+int verify_opts( nt_opts * opts, const char * prog )
 {
    int ac, errs = 0;   /* number of requested action types */
 
@@ -687,7 +687,7 @@ int verify_opts( nt_opts * opts, char * prog )
 /*----------------------------------------------------------------------
  * re-assemble the command string into opts->command
  *----------------------------------------------------------------------*/
-int fill_cmd_string( nt_opts * opts, int argc, char * argv[])
+int fill_cmd_string( nt_opts * opts, int argc, const char * argv[])
 {
    char * cp;
    size_t len, c, remain = sizeof(opts->command);  /* max command len */

--- a/niftilib/nifti1_tool.h
+++ b/niftilib/nifti1_tool.h
@@ -31,7 +31,7 @@ typedef struct{
    int      new_datatype;        /* datatype for new image        */
    int      debug, keep_hist;    /* debug level and history flag  */
    int      overwrite;           /* overwrite flag                */
-   char *   prefix;              /* for output file               */
+   const char *   prefix;              /* for output file               */
    str_list elist;               /* extension strings             */
    int_list etypes;              /* extension type list           */
    str_list flist;               /* fields (to display or modify) */
@@ -135,18 +135,18 @@ int disp_field       ( const char *mesg,field_s *fieldp,void *str,int nfields,in
 int disp_field_s_list( const char *mesg, field_s *, int nfields);
 int disp_nt_opts     ( const char *mesg, nt_opts * opts);
 int disp_raw_data    (void * data, int type, int nvals, char space,int newline);
-int fill_cmd_string  (nt_opts * opts, int argc, char * argv[]);
+int fill_cmd_string  (nt_opts * opts, int argc, const char * argv[]);
 int fill_field       (field_s *fp, int type, int offset, int num, const char *name);
 int fill_hdr_field_array(field_s * nh_fields);
 int fill_nim_field_array(field_s * nim_fields);
 int fill_ana_field_array(field_s * ah_fields);
 int modify_all_fields(void *basep, nt_opts *opts, field_s *fields, int flen);
 int modify_field     (void * basep, field_s * field, const char * data);
-int process_opts     (int argc, char * argv[], nt_opts * opts);
+int process_opts     (int argc, const char * argv[], nt_opts * opts);
 int remove_ext_list  (nifti_image * nim, const char ** elist, int len);
 int usage            (const char * prog, int level);
 int use_full         (const char * prog);
-int verify_opts      (nt_opts * opts, char * prog);
+int verify_opts      (nt_opts * opts, const char * prog);
 int write_hdr_to_file(nifti_1_header * nhdr, const char * fname);
 
 /* wrappers for nifti reading functions (allow MAKE_IM) */

--- a/niftilib/nifti_tester001.c
+++ b/niftilib/nifti_tester001.c
@@ -212,7 +212,7 @@ int main (int argc, const char *argv[])
      * Add an extension to test extension reading
      */
     {
-    static char ext[] = "THIS IS A TEST";
+    const char ext[] = "THIS IS A TEST";
     snprintf(buf,sizeof(buf),"nifti_add_extension %s",write_image_filename[filenameindex]);
     PrintTest(buf,
               nifti_add_extension(reference_image,
@@ -670,7 +670,7 @@ int main (int argc, const char *argv[])
             false,&Errors);
   }
   {
-  static char x[16] = { 'a','b','c','d','e','f','g','h',
+  char x[16] = { 'a','b','c','d','e','f','g','h',
                         'H','G','F','E','D','C','B','A' };
   nifti_swap_Nbytes(1,16,(void *)x);
   PrintTest("nifti_swap_16bytes",
@@ -682,7 +682,7 @@ int main (int argc, const char *argv[])
 
   }
   {
-  static char x[8] = { 'a','b','c','d','D','C','B','A' };
+  char x[8] = { 'a','b','c','d','D','C','B','A' };
   nifti_swap_Nbytes(1,8,(void *)x);
   PrintTest("nifti_swap_8bytes",
             x[0] != 'A' || x[1] != 'B' || x[2] != 'C' || x[3] != 'D' ||

--- a/niftilib/nifti_tester001.c
+++ b/niftilib/nifti_tester001.c
@@ -129,21 +129,21 @@ static void compare_reference_image_values(nifti_image const * const reference_i
     printf("ERROR: Reloaded image is NULL\n");
     exit(-1);
   }
-  PrintTest("Checking nifti_type",(reference_image->nifti_type!=reloaded_image->nifti_type),false,Errors);
-  PrintTest("Checking fname",(strcmp(reference_image->fname,reloaded_image->fname)),false,Errors);
-  PrintTest("Checking iname",(strcmp(reference_image->iname,reloaded_image->iname)),false,Errors);
-  PrintTest("Checking ndim",(reference_image->ndim!=reloaded_image->ndim),false,Errors);
-  PrintTest("Checking nx",(reference_image->nx!=reloaded_image->nx),false,Errors);
-  PrintTest("Checking ny",(reference_image->ny!=reloaded_image->ny),false,Errors);
-  PrintTest("Checking nz",(reference_image->nz!=reloaded_image->nz),false,Errors);
-  PrintTest("Checking nt",(reference_image->nt!=reloaded_image->nt),false,Errors);
-  PrintTest("Checking nu",(reference_image->nu!=reloaded_image->nu),false,Errors);
-  PrintTest("Checking dx",(reference_image->dx!=reloaded_image->dx),false,Errors);
-  PrintTest("Checking dy",(reference_image->dy!=reloaded_image->dy),false,Errors);
-  PrintTest("Checking dz",(reference_image->dz!=reloaded_image->dz),false,Errors);
-  PrintTest("Checking dt",(reference_image->dt!=reloaded_image->dt),false,Errors);
-  PrintTest("Checking du",(reference_image->du!=reloaded_image->du),false,Errors);
-  PrintTest("Checking datatype",(reference_image->datatype!=reloaded_image->datatype),false,Errors);
+  PrintTest("Checking nifti_type",(reference_image->nifti_type!=reloaded_image->nifti_type),true,Errors);
+  PrintTest("Checking fname",(strcmp(reference_image->fname,reloaded_image->fname)),true,Errors);
+  PrintTest("Checking iname",(strcmp(reference_image->iname,reloaded_image->iname)),true,Errors);
+  PrintTest("Checking ndim",(reference_image->ndim!=reloaded_image->ndim),true,Errors);
+  PrintTest("Checking nx",(reference_image->nx!=reloaded_image->nx),true,Errors);
+  PrintTest("Checking ny",(reference_image->ny!=reloaded_image->ny),true,Errors);
+  PrintTest("Checking nz",(reference_image->nz!=reloaded_image->nz),true,Errors);
+  PrintTest("Checking nt",(reference_image->nt!=reloaded_image->nt),true,Errors);
+  PrintTest("Checking nu",(reference_image->nu!=reloaded_image->nu),true,Errors);
+  PrintTest("Checking dx",(reference_image->dx!=reloaded_image->dx),true,Errors);
+  PrintTest("Checking dy",(reference_image->dy!=reloaded_image->dy),true,Errors);
+  PrintTest("Checking dz",(reference_image->dz!=reloaded_image->dz),true,Errors);
+  PrintTest("Checking dt",(reference_image->dt!=reloaded_image->dt),true,Errors);
+  PrintTest("Checking du",(reference_image->du!=reloaded_image->du),true,Errors);
+  PrintTest("Checking datatype",(reference_image->datatype!=reloaded_image->datatype),true,Errors);
   {
   const unsigned int NumVoxels=reference_image->nx*reference_image->ny*reference_image->nz*reference_image->nt*reference_image->nu;
   PrintTest("Check loaded data is non null",(reloaded_image->data==0),true,Errors);
@@ -155,16 +155,16 @@ static void compare_reference_image_values(nifti_image const * const reference_i
       /*printf("%d ",CurrVoxel); fflush(stdout);*/
       if( ((int *)(reference_image->data))[CurrVoxel] !=  ((int *)(reloaded_image->data))[CurrVoxel])
         {
-        PrintTest("Incorrect Pixel Value Found",0,false,Errors);
+        PrintTest("Incorrect Pixel Value Found",0,true,Errors);
         }
       }
   }
   }
-  PrintTest("Checking xyz_units",(reference_image->xyz_units!=reloaded_image->xyz_units),false,Errors);
-  PrintTest("Checking time_units",(reference_image->time_units!=reloaded_image->time_units),false,Errors);
-  PrintTest("Checking intent_code",(reference_image->intent_code!=reloaded_image->intent_code),false,Errors);
-  PrintTest("Checking intent_name",(strncmp(reference_image->intent_name,reloaded_image->intent_name,16) )!=0,false,Errors);
-  PrintTest("Checking description",(strncmp(reference_image->descrip,reloaded_image->descrip,80))!=0,false,Errors);
+  PrintTest("Checking xyz_units",(reference_image->xyz_units!=reloaded_image->xyz_units),true,Errors);
+  PrintTest("Checking time_units",(reference_image->time_units!=reloaded_image->time_units),true,Errors);
+  PrintTest("Checking intent_code",(reference_image->intent_code!=reloaded_image->intent_code),true,Errors);
+  PrintTest("Checking intent_name",(strncmp(reference_image->intent_name,reloaded_image->intent_name,16) )!=0,true,Errors);
+  PrintTest("Checking description",(strncmp(reference_image->descrip,reloaded_image->descrip,80))!=0,true,Errors);
 }
 
 int main (int argc, const char *argv[])
@@ -218,11 +218,11 @@ int main (int argc, const char *argv[])
               nifti_add_extension(reference_image,
                                   ext,sizeof(ext),
                                   NIFTI_ECODE_COMMENT) == -1,
-              false,&Errors);
+              true,&Errors);
     snprintf(buf,sizeof(buf),"valid_nifti_extension %s",write_image_filename[filenameindex]);
     PrintTest("valid_nifti_extensions",
               valid_nifti_extensions(reference_image) == 0,
-              false,&Errors);
+              true,&Errors);
     }
     PrintTest("Create reference image",reference_image==0,true,&Errors);
     if( nifti_image_write_status( reference_image ) )
@@ -240,16 +240,16 @@ int main (int argc, const char *argv[])
       nifti_image *nim = nifti_simple_init_nim();
       PrintTest("nifti_copy_extension",
                 nifti_copy_extensions(nim,reference_image),
-                false,&Errors);
+                true,&Errors);
 
       nifti_image_free(nim);
       nim = nifti_copy_nim_info(reference_image);
       PrintTest("nifti_copy_nim_info",
                 nim == 0,
-                false,&Errors);
+                true,&Errors);
       PrintTest("nifti_nim_is_valid",
                 nifti_nim_is_valid(nim,0) == 0,
-                false,&Errors);
+                true,&Errors);
 
 
       nifti_image_free(nim);
@@ -270,7 +270,7 @@ int main (int argc, const char *argv[])
     snprintf(buf,sizeof(buf),"reload valid_nifti_extensions %s",write_image_filename[filenameindex]);
       PrintTest(buf,
                 CompressedTwoFile ? result != 0 : result == 0,
-                false,&Errors);
+                true,&Errors);
     }
     nifti_image_infodump(reloaded_image);
     compare_reference_image_values(reference_image,reloaded_image,&Errors);
@@ -288,15 +288,15 @@ int main (int argc, const char *argv[])
      * test some error paths in the nifti_image_read_bricks
      */
     nim_orig = nifti_image_read_bricks(reference_image->fname,0,blist, &NB_orig);
-    PrintTest("invalid arg bricked image read 1",nim_orig != 0,false,&Errors);
+    PrintTest("invalid arg bricked image read 1",nim_orig != 0,true,&Errors);
 
     nim_orig   = nifti_image_read_bricks(reference_image->fname, 0, NULL,  &NB_orig);
-    PrintTest("Reload of bricked image",nim_orig == 0,false,&Errors);
+    PrintTest("Reload of bricked image",nim_orig == 0,true,&Errors);
     nifti_free_NBL(&NB_orig);
     nifti_image_free(nim_orig);
 
     nim_select = nifti_image_read_bricks(reference_image->fname, 5, blist, &NB_select);
-    PrintTest("Reload of bricked image with blist",nim_orig == 0,false,&Errors);
+    PrintTest("Reload of bricked image with blist",nim_orig == 0,true,&Errors);
     nifti_free_NBL(&NB_select);
     nifti_image_free(nim_select);
 
@@ -306,18 +306,18 @@ int main (int argc, const char *argv[])
      */
     PrintTest("nifti_update_dims_from_array -- valid dims",
               nifti_update_dims_from_array(reference_image) != 0,
-              false,&Errors);
+              true,&Errors);
     reference_image->dim[0] = 8;
     PrintTest("nifti_update_dims_from_array -- invalid dims",
               nifti_update_dims_from_array(reference_image) == 0,
-              false,&Errors);
+              true,&Errors);
     {
     nifti_1_header x = nifti_convert_nim2nhdr(reference_image);
     char local_buffer[512];
     snprintf(local_buffer,sizeof(local_buffer),"nifti_hdr_looks_good %s",reference_image->fname);
     PrintTest(local_buffer,
               !nifti_hdr_looks_good(&x),
-              false,&Errors);
+              true,&Errors);
     }
 
     nifti_image_free(reference_image);
@@ -330,23 +330,23 @@ int main (int argc, const char *argv[])
   PrintTest("nifti_findimgname",
             imgname == 0 ||
             strcmp(imgname,"ATestReferenceImageForReadingAndWriting.img") != 0,
-            false,&Errors);
+            true,&Errors);
   free(imgname);
   }
   {
   int IsNiftiFile;
   IsNiftiFile = is_nifti_file(write_image_filename[0]);
   PrintTest("is_nifti_file0",
-            IsNiftiFile != 1,false,&Errors);
+            IsNiftiFile != 1,true,&Errors);
   IsNiftiFile = is_nifti_file(write_image_filename[1]);
   PrintTest("is_nifti_file1",
-            IsNiftiFile != 2,false,&Errors);
+            IsNiftiFile != 2,true,&Errors);
   IsNiftiFile = is_nifti_file(write_image_filename[3]);
   PrintTest("is_nifti_file2",
-            IsNiftiFile != 1,false,&Errors);
+            IsNiftiFile != 1,true,&Errors);
   IsNiftiFile = is_nifti_file(write_image_filename[4]);
   PrintTest("is_nifti_file2",
-            IsNiftiFile != 2,false,&Errors);
+            IsNiftiFile != 2,true,&Errors);
   }
 
   }
@@ -365,7 +365,7 @@ int main (int argc, const char *argv[])
 
   nifti_image * reloaded_image = nifti_image_read("TestAsciiImage.nia",1);
   PrintTest("Read/Write Ascii image",
-            reloaded_image == 0,false,&Errors);
+            reloaded_image == 0,true,&Errors);
   nifti_image_free(reference_image);
   nifti_image_free(reloaded_image);
   }
@@ -420,18 +420,18 @@ int main (int argc, const char *argv[])
     {
     int KnownValid=nifti_validfilename(FILE_NAMES[fni]);
     snprintf(TEMP_STR,sizeof(TEMP_STR),"nifti_validfilename(\"%s\")=%d",FILE_NAMES[fni],KnownValid);
-    PrintTest(TEMP_STR,KnownValid != KNOWN_nifti_validfilename[fni],false,&Errors);
+    PrintTest(TEMP_STR,KnownValid != KNOWN_nifti_validfilename[fni],true,&Errors);
     }
     {
     int KnownValid=nifti_is_complete_filename(FILE_NAMES[fni]);
     snprintf(TEMP_STR,sizeof(TEMP_STR),"nifti_is_complete_filename(\"%s\")=%d",FILE_NAMES[fni],KnownValid);
-    PrintTest(TEMP_STR,KnownValid != KNOWN_nifti_is_complete_filename[fni],false,&Errors);
+    PrintTest(TEMP_STR,KnownValid != KNOWN_nifti_is_complete_filename[fni],true,&Errors);
     }
 
     {
     char * basename=nifti_makebasename(FILE_NAMES[fni]);
     snprintf(TEMP_STR,sizeof(TEMP_STR),"nifti_makebasename(\"%s\")=\"%s\"",FILE_NAMES[fni],basename);
-    PrintTest(TEMP_STR,strcmp(basename,KNOWN_FILE_BASENAMES[fni]) != 0,false,&Errors);
+    PrintTest(TEMP_STR,strcmp(basename,KNOWN_FILE_BASENAMES[fni]) != 0,true,&Errors);
     free(basename);
 
     }
@@ -448,12 +448,12 @@ int main (int argc, const char *argv[])
   PrintTest(
             "nifti_image_read_bricks 1",
             nifti_image_read_bricks((char *)0,-1,(const int *)0,(nifti_brick_list *)0) != 0,
-            false,
+            true,
             &Errors);
   PrintTest(
             "nifti_image_read_bricks 1",
             nifti_image_read_bricks("NOFILE.NOFILE",-1,(const int *)0,(nifti_brick_list *)0) != 0,
-            false,
+            true,
             &Errors);
   }
   /*
@@ -466,7 +466,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                                   \
             buf,                                                        \
             strcmp(nifti_datatype_string(constant),string) != 0,        \
-            false,                                            \
+            true,                                            \
             &Errors);                                                   \
   }
   nifti_datatype_test(DT_UNKNOWN,"UNKNOWN");
@@ -493,7 +493,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                   \
             buf,                                        \
             nifti_is_inttype(constant) != rval,         \
-            false,                            \
+            true,                            \
             &Errors);                                   \
   }
   nifti_is_inttype_test(DT_UNKNOWN,0);
@@ -520,7 +520,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                           \
             buf,                                                \
             strcmp(nifti_units_string(constant),string) != 0,   \
-            false,                                    \
+            true,                                    \
             &Errors);                                           \
   }
   nifti_units_string_test(NIFTI_UNITS_METER,"m");
@@ -539,7 +539,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                           \
             buf,                                                \
             strcmp(nifti_intent_string(constant),string) != 0,  \
-            false,                                    \
+            true,                                    \
             &Errors);                                           \
   }
   nifti_intent_string_test(NIFTI_INTENT_CORREL,"Correlation statistic");
@@ -585,7 +585,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                           \
             buf,                                                \
             strcmp(nifti_slice_string(constant),string) != 0,   \
-            false,                                    \
+            true,                                    \
             &Errors);                                           \
   }
   nifti_slice_string_test(NIFTI_SLICE_SEQ_INC,"sequential_increasing");
@@ -601,7 +601,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                                   \
             buf,                                                        \
             strcmp(nifti_orientation_string(constant),string) != 0,     \
-            false,                                            \
+            true,                                            \
             &Errors);                                                   \
   }
   nifti_orientation_string_test(NIFTI_L2R,"Left-to-Right");
@@ -621,7 +621,7 @@ int main (int argc, const char *argv[])
   PrintTest(                                           \
             buf,                                                \
             nbyper != Nbyper || swapsize != Swapsize,           \
-            false,                                    \
+            true,                                    \
             &Errors);                                           \
   }
 
@@ -657,7 +657,7 @@ int main (int argc, const char *argv[])
             qx != 0.000000 || qy != 0.000000 || qz != 0.000000 ||
             dx != 1.000000 || dy != 1.000000 || dz != 1.000000 ||
             qfac != 1.000000,
-            false,&Errors);
+            true,&Errors);
   }
   {
   mat44 x = nifti_make_orthog_mat44(0.14,0.0,0.0,
@@ -667,7 +667,7 @@ int main (int argc, const char *argv[])
   PrintTest("nifti_make_orthog_mat44",
             x.m[0][0] != 1.0 || x.m[1][1] != 1.0 ||
             x.m[2][2] != 1.0 || x.m[3][3] != 1.0,
-            false,&Errors);
+            true,&Errors);
   }
   {
   char x[16] = { 'a','b','c','d','e','f','g','h',
@@ -678,7 +678,7 @@ int main (int argc, const char *argv[])
             x[4] != 'E' || x[5] != 'F' || x[6] != 'G' || x[7] != 'H' ||
             x[8] != 'h' || x[9] != 'g' || x[10] != 'f' || x[11] != 'e' ||
             x[12] != 'd' || x[13] != 'c' || x[14] != 'b' || x[15] != 'a',
-            false,&Errors);
+            true,&Errors);
 
   }
   {
@@ -687,7 +687,7 @@ int main (int argc, const char *argv[])
   PrintTest("nifti_swap_8bytes",
             x[0] != 'A' || x[1] != 'B' || x[2] != 'C' || x[3] != 'D' ||
             x[4] != 'd' || x[5] != 'c' || x[6] != 'b' || x[7] != 'a',
-            false,&Errors);
+            true,&Errors);
 
   }
   {
@@ -696,7 +696,7 @@ int main (int argc, const char *argv[])
    */
   nifti_image *nim = nifti_simple_init_nim();
   PrintTest("nifti_simple_init_nim",
-            nim == 0,false,&Errors);
+            nim == 0,true,&Errors);
   nifti_image_free(nim); nim = 0;
   /*
    * test nifti_image_open
@@ -704,14 +704,14 @@ int main (int argc, const char *argv[])
   znzFile f = nifti_image_open("ATestReferenceImageForReadingAndWriting.hdr","r",&nim);
   PrintTest("nifti_image_open",
             nim == 0 || f == 0,
-            false,&Errors);
+            true,&Errors);
   PrintTest("nifti_image_load",
             nifti_image_load(nim) == -1,
-            false,&Errors);
+            true,&Errors);
   nifti_image_unload(nim);
   PrintTest("nifti_image_unload",
             nim->data != 0,
-            false,&Errors);
+            true,&Errors);
 
   znzclose(f);
   nifti_image_free(nim);

--- a/niftilib/nifti_tester001.c
+++ b/niftilib/nifti_tester001.c
@@ -419,18 +419,18 @@ int main (int argc, const char *argv[])
     printf("\nTesting \"%s\" filename\n",FILE_NAMES[fni]);
     {
     int KnownValid=nifti_validfilename(FILE_NAMES[fni]);
-    snprintf(TEMP_STR,256,"nifti_validfilename(\"%s\")=%d",FILE_NAMES[fni],KnownValid);
+    snprintf(TEMP_STR,sizeof(TEMP_STR),"nifti_validfilename(\"%s\")=%d",FILE_NAMES[fni],KnownValid);
     PrintTest(TEMP_STR,KnownValid != KNOWN_nifti_validfilename[fni],false,&Errors);
     }
     {
     int KnownValid=nifti_is_complete_filename(FILE_NAMES[fni]);
-    snprintf(TEMP_STR,256,"nifti_is_complete_filename(\"%s\")=%d",FILE_NAMES[fni],KnownValid);
+    snprintf(TEMP_STR,sizeof(TEMP_STR),"nifti_is_complete_filename(\"%s\")=%d",FILE_NAMES[fni],KnownValid);
     PrintTest(TEMP_STR,KnownValid != KNOWN_nifti_is_complete_filename[fni],false,&Errors);
     }
 
     {
     char * basename=nifti_makebasename(FILE_NAMES[fni]);
-    snprintf(TEMP_STR,256,"nifti_makebasename(\"%s\")=\"%s\"",FILE_NAMES[fni],basename);
+    snprintf(TEMP_STR,sizeof(TEMP_STR),"nifti_makebasename(\"%s\")=\"%s\"",FILE_NAMES[fni],basename);
     PrintTest(TEMP_STR,strcmp(basename,KNOWN_FILE_BASENAMES[fni]) != 0,false,&Errors);
     free(basename);
 

--- a/niftilib/nifti_tester002.c
+++ b/niftilib/nifti_tester002.c
@@ -21,7 +21,7 @@ int main (int argc, const char *argv[])
   /*
    * add an extension to the dummy
    */
-  static char ext[] = "THIS IS A TEST";
+  const char ext[] = "THIS IS A TEST";
   nifti_add_extension(i1,ext,sizeof(ext),NIFTI_ECODE_COMMENT);
   /*
    * make a new nim from the dummy


### PR DESCRIPTION
@hjmjohnson I've been excited to try [clang's -fbounds-safety](https://clang.llvm.org/docs/BoundsSafety.html) and niftic_lib is a great place to try it.

These are some initial necessary but insufficient fixes to compile with that option.

This work is actually from a few months ago, but I haven't had time to continue, but thought I'd share what I started.