### PR TITLE
Fixed some warnings from the new cppcheck 2.19

### DIFF
--- a/fsliolib/fslio.c
+++ b/fsliolib/fslio.c
@@ -809,7 +809,6 @@ void* FslReadAllVolumes(FSLIO* fslio, char* filename)
   /* check for failure, from David Akers */
   if (fslio->niftiptr == NULL) {
         FSLIOERR("FslReadAllVolumes: error reading NIfTI image");
-        return(NULL);
   }
 
   FslSetFileType(fslio,fslio->niftiptr->nifti_type);
@@ -2092,7 +2091,6 @@ FSLIO * FslReadHeader(char *fname)
 
   if (fslio->niftiptr == NULL) {
         FSLIOERR("FslReadHeader: error reading header information");
-        return(NULL);
   }
 
   fslio->file_mode = FslGetReadFileType(fslio);

--- a/nifticdf/nifticdf.c
+++ b/nifticdf/nifticdf.c
@@ -11050,6 +11050,8 @@ int nifti_intent_code( const char *name )
    if( name == NULL || *name == '\0' ) return -1 ;
 
    unam = (char *)malloc(strlen(name)+1);
+   if (!unam)
+      return -1 ;
    strcpy(unam,name);
    for( upt=unam ; *upt != '\0' ; upt++ ) *upt = (char)toupper(*upt) ;
 


### PR DESCRIPTION
- duplicateBreak,fsliolib/fslio.c:812,style,Consecutive return, break, continue, goto or throw statements are unnecessary.
- duplicateBreak,fsliolib/fslio.c:2095,style,Consecutive return, break, continue, goto or throw statements are unnecessary.
- nullPointerOutOfMemory,nifticdf/nifticdf.c:11053,warning,If memory allocation fails, then there is a possible null pointer dereference: upt